### PR TITLE
fix: Remove all backward compatibility code (Issue #59)

### DIFF
--- a/apps/cli/src/cli-parser.ts
+++ b/apps/cli/src/cli-parser.ts
@@ -56,8 +56,10 @@ export class CliParser {
       } else if (!arg.startsWith('-')) {
         // Non-flag arg before command - invalid
         throw new Error(`Unexpected argument: ${arg}`);
+      } else {
+        // Unknown flag - error instead of ignoring
+        throw new Error(`Unknown flag: ${arg}`);
       }
-      // Ignore unknown flags for forward compatibility
       
       i++;
     }

--- a/packages/document-set/src/builders/from-table.ts
+++ b/packages/document-set/src/builders/from-table.ts
@@ -21,7 +21,7 @@ export interface FromTableOptions {
   /**
    * The original query that produced this table (if any).
    */
-  sourceQuery?: import('@mmt/entities').Query;
+  sourceQuery?: import('@mmt/entities').QueryInput;
   
   /**
    * Query execution time in milliseconds.

--- a/packages/document-set/src/document-set.ts
+++ b/packages/document-set/src/document-set.ts
@@ -1,7 +1,7 @@
 import type {
   Document,
   OperationReadyDocumentSet,
-  Query,
+  QueryInput,
 } from '@mmt/entities';
 import type { ParsedArrayField } from './types.js';
 import { 
@@ -29,7 +29,7 @@ type Table = ReturnType<typeof aq.table>;
  */
 export class DocumentSet implements OperationReadyDocumentSet {
   readonly _type = 'DocumentSet' as const;
-  readonly sourceQuery?: Query; // Can be IndexerQuery or entities QueryInput
+  readonly sourceQuery?: QueryInput; // Can be IndexerQuery or entities QueryInput
   readonly documentCount: number;
   readonly limit: number;
   readonly tableRef: Table;
@@ -44,7 +44,7 @@ export class DocumentSet implements OperationReadyDocumentSet {
   
   constructor(data: {
     tableRef: Table;
-    sourceQuery?: Query;
+    sourceQuery?: QueryInput;
     limit?: number;
     executionTime?: number;
   }) {

--- a/packages/entities/src/document-set.schema.ts
+++ b/packages/entities/src/document-set.schema.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 import { DocumentSchema } from './document.schema.js';
-import { QuerySchema } from './query.schema.js';
+import { QueryInputSchema } from './query.schema.js';
 
 /**
  * Operation-ready document set that can be passed to mutation operations.
@@ -11,7 +11,7 @@ export const OperationReadyDocumentSetSchema = z.object({
   _type: z.literal('DocumentSet'),
   
   // Original query that produced this set
-  sourceQuery: QuerySchema.optional(),
+  sourceQuery: QueryInputSchema.optional(),
   
   // Number of documents in the set
   documentCount: z.number().min(0),

--- a/packages/entities/src/index.test.ts
+++ b/packages/entities/src/index.test.ts
@@ -3,14 +3,14 @@ import {
   ConfigSchema,
   DocumentMetadataSchema,
   DocumentSchema,
-  QuerySchema,
+  QueryInputSchema,
   OperationSchema,
   VaultSchema,
   ExecutionResultSchema,
   type Config,
   type DocumentMetadata,
   type Document,
-  type Query,
+  type QueryInput,
   type Operation,
   type Vault,
   type ExecutionResult,
@@ -99,12 +99,12 @@ describe('Entity Schemas', () => {
     });
   });
 
-  describe('QuerySchema with namespaces', () => {
+  describe('QueryInputSchema with namespaces', () => {
     it('should validate query with namespace format', () => {
       // GIVEN: Query with namespace:property format
-      // WHEN: Validating against QuerySchema
+      // WHEN: Validating against QueryInputSchema
       // THEN: Valid because all properties use correct namespace prefixes (fs:, fm:, content:)
-      const query: Query = {
+      const query: QueryInput = {
         'fs:path': 'folder/**',
         'fs:modified': '>2024-01-01',
         'fm:status': 'draft',
@@ -114,30 +114,30 @@ describe('Entity Schemas', () => {
         order: 'desc',
       };
       
-      const result = QuerySchema.safeParse(query);
+      const result = QueryInputSchema.safeParse(query);
       expect(result.success).toBe(true);
     });
 
     it('should reject query without namespace prefix', () => {
       // GIVEN: Query properties without namespace prefixes
-      // WHEN: Validating against QuerySchema
+      // WHEN: Validating against QueryInputSchema
       // THEN: Invalid because all query properties must have namespace (prevents ambiguity)
       const query = {
         path: 'folder/', // Missing namespace
         status: 'draft', // Missing namespace
       };
       
-      const result = QuerySchema.safeParse(query);
+      const result = QueryInputSchema.safeParse(query);
       expect(result.success).toBe(false);
     });
 
     it('should validate empty query', () => {
       // GIVEN: An empty query object
-      // WHEN: Validating against QuerySchema
+      // WHEN: Validating against QueryInputSchema
       // THEN: Valid because empty queries select all documents
-      const query: Query = {};
+      const query: QueryInput = {};
       
-      const result = QuerySchema.safeParse(query);
+      const result = QueryInputSchema.safeParse(query);
       expect(result.success).toBe(true);
     });
 

--- a/packages/entities/src/index.ts
+++ b/packages/entities/src/index.ts
@@ -55,7 +55,6 @@ import {
 } from './document.schema.js';
 import {
   QueryOperatorSchema,
-  QuerySchema,
   StructuredQuerySchema,
 } from './query.schema.js';
 import {
@@ -104,71 +103,6 @@ import {
   CommandResultSchema,
   CommandResults,
 } from './cli.schema.js';
-
-/**
- * Convenience export of all schemas grouped by domain.
- * This maintains backward compatibility with the previous single-file structure.
- */
-export const schemas = {
-  // Core objects
-  Config: ConfigSchema,
-  AppContext: AppContextSchema,
-  BaseDocumentMetadata: BaseDocumentMetadataSchema,
-  DocumentMetadata: DocumentMetadataSchema,
-  Document: DocumentSchema,
-  DocumentSet: DocumentSetSchema,
-  
-  // Query and operations
-  QueryOperator: QueryOperatorSchema,
-  QueryInput: QueryInputSchema,
-  Query: QuerySchema, // Alias for QueryInput
-  StructuredQuery: StructuredQuerySchema,
-  MoveOperation: MoveOperationSchema,
-  UpdateFrontmatterOperation: UpdateFrontmatterOperationSchema,
-  RemoveFrontmatterOperation: RemoveFrontmatterOperationSchema,
-  DeleteOperation: DeleteOperationSchema,
-  CreateOperation: CreateOperationSchema,
-  Operation: OperationSchema,
-  
-  // Vault and execution
-  VaultIndex: VaultIndexSchema,
-  Vault: VaultSchema,
-  VaultContext: VaultContextSchema,
-  LinkUpdate: LinkUpdateSchema,
-  ExecutionResult: ExecutionResultSchema,
-  
-  // UI and persistence
-  Snapshot: SnapshotSchema,
-  ColumnConfig: ColumnConfigSchema,
-  TableViewConfig: TableViewConfigSchema,
-  
-  // Events and results
-  FileOperationResult: FileOperationResultSchema,
-  IndexUpdateEvent: IndexUpdateEventSchema,
-  
-  // Scripting
-  SelectCriteria: SelectCriteriaSchema,
-  OperationType: OperationTypeSchema,
-  ScriptOperation: ScriptOperationSchema,
-  OutputFormat: OutputFormatSchema,
-  OutputConfig: OutputConfigSchema,
-  ExecuteOptions: ExecuteOptionsSchema,
-  ExecutionOptions: ExecutionOptionsSchema,
-  OperationPipeline: OperationPipelineSchema,
-  ScriptContext: ScriptContextSchema,
-  SuccessResult: SuccessResultSchema,
-  FailureResult: FailureResultSchema,
-  SkippedResult: SkippedResultSchema,
-  ExecutionStats: ExecutionStatsSchema,
-  ScriptExecutionResult: ScriptExecutionResultSchema,
-  
-  // Document sets
-  OperationReadyDocumentSet: OperationReadyDocumentSetSchema,
-  ToDocumentSetOptions: ToDocumentSetOptionsSchema,
-  
-  // CLI
-  CommandResult: CommandResultSchema,
-} as const;
 
 // Also export the CommandResults helper
 export { CommandResults };

--- a/packages/entities/src/query.schema.ts
+++ b/packages/entities/src/query.schema.ts
@@ -200,10 +200,3 @@ export const StructuredQuerySchema = z.object({
 });
 
 export type StructuredQuery = z.infer<typeof StructuredQuerySchema>;
-
-/**
- * Alias for backward compatibility.
- * @deprecated Use QueryInput instead
- */
-export const QuerySchema = QueryInputSchema;
-export type Query = QueryInput;

--- a/packages/entities/src/scripting.schema.ts
+++ b/packages/entities/src/scripting.schema.ts
@@ -35,8 +35,6 @@ export const OperationTypeSchema = z.enum([
   'analyze',
   'transform',
   'aggregate',
-  // Legacy
-  'custom',
 ]).describe('Type of operation to perform');
 
 /**

--- a/packages/query-parser/src/index.test.ts
+++ b/packages/query-parser/src/index.test.ts
@@ -3,7 +3,7 @@
  */
 
 import { describe, it, expect } from 'vitest';
-import type { Query } from '@mmt/entities';
+import type { QueryInput } from '@mmt/entities';
 import { parseQuery } from './index.js';
 
 describe('parseQuery', () => {
@@ -11,7 +11,7 @@ describe('parseQuery', () => {
     // GIVEN: A query with namespace:property format
     // WHEN: Parsing the query to extract namespace-based structure
     // THEN: Properties are organized into separate namespace objects
-    const input: Query = {
+    const input: QueryInput = {
       'fs:path': 'posts/**',
       'fm:status': 'published',
       'content:text': 'important',
@@ -32,7 +32,7 @@ describe('parseQuery', () => {
     // GIVEN: A query with sort options
     // WHEN: Parsing a query that includes sort and order fields
     // THEN: Sort options are structured into a sort object with field and order
-    const input: Query = {
+    const input: QueryInput = {
       'fs:path': 'posts/**',
       sort: 'modified',
       order: 'desc',
@@ -52,7 +52,7 @@ describe('parseQuery', () => {
     // GIVEN: A query with invalid keys
     // WHEN: Parsing a query containing keys without namespace prefixes
     // THEN: Invalid keys are ignored (namespace requirement enforced)
-    const input: Query = {
+    const input: QueryInput = {
       'fs:path': 'posts/**',
       invalidKey: 'value', // No namespace
     };
@@ -70,7 +70,7 @@ describe('parseQuery', () => {
     // GIVEN: A query using all namespaces
     // WHEN: Parsing a query with fs:, fm:, content:, and inline: prefixes
     // THEN: All namespaces are parsed into their respective objects
-    const input: Query = {
+    const input: QueryInput = {
       'fs:path': 'posts/**',
       'fs:name': 'README',
       'fm:status': 'draft',

--- a/packages/scripting/src/analysis-pipeline.ts
+++ b/packages/scripting/src/analysis-pipeline.ts
@@ -6,18 +6,3 @@ import type { Table } from 'arquero';
  * The actual document/table conversion functions are now in @mmt/document-set.
  */
 export { aq };
-
-/**
- * @deprecated Use fromTable from @mmt/document-set instead
- */
-export { fromTable as tableToDocumentSet } from '@mmt/document-set';
-
-/**
- * @deprecated Use documentsToTable from @mmt/document-set instead
- */
-export { documentsToTable } from '@mmt/document-set';
-
-/**
- * @deprecated Use materialize from @mmt/document-set instead
- */
-export { materialize as materializeDocuments } from '@mmt/document-set';

--- a/packages/scripting/src/analysis-runner.ts
+++ b/packages/scripting/src/analysis-runner.ts
@@ -56,14 +56,6 @@ export class AnalysisRunner {
     for (const operation of operations) {
       if (operation.type === 'analyze' || operation.type === 'transform' || operation.type === 'aggregate') {
         table = await this.executeAnalysisOperation(table, operation);
-      } else if (operation.type === 'custom' && 'action' in operation && operation.action === 'analyze' && 'handler' in operation) {
-        // Support legacy custom operations with handlers
-        const context: AnalysisContext = { table, aq };
-        const handler = (operation as any).handler;
-        const result = await handler(documents, context);
-        if (result && result.table) {
-          table = result.table;
-        }
       }
     }
     
@@ -74,7 +66,6 @@ export class AnalysisRunner {
     
     return {
       table,
-      output: undefined, // Legacy field, kept for compatibility
     };
   }
   

--- a/packages/scripting/src/index.ts
+++ b/packages/scripting/src/index.ts
@@ -9,11 +9,10 @@ export { Script } from './script.interface.js';
 export { ScriptRunner, type ScriptRunnerOptions } from './script-runner.js';
 export { ResultFormatter, type FormatOptions } from './result-formatter.js';
 export { AnalysisRunner } from './analysis-runner.js';
-export { documentsToTable, tableToDocumentSet } from './analysis-pipeline.js';
 export { MarkdownReportGenerator, type ReportGenerationOptions } from './markdown-report-generator.js';
 
 // Re-export Arquero for script usage
-export * as aq from 'arquero';
+export { aq } from './analysis-pipeline.js';
 
 // Re-export relevant types from entities for convenience
 export type {

--- a/packages/scripting/src/script-runner.ts
+++ b/packages/scripting/src/script-runner.ts
@@ -146,8 +146,7 @@ export class ScriptRunner {
 
     // Check if this is an analysis pipeline
     const hasAnalysisOps = pipeline.operations.some(op => 
-      op.type === 'analyze' || op.type === 'transform' || op.type === 'aggregate' ||
-      (op.type === 'custom' && 'action' in op && op.action === 'analyze')
+      op.type === 'analyze' || op.type === 'transform' || op.type === 'aggregate'
     );
     
     if (hasAnalysisOps) {
@@ -419,11 +418,6 @@ export class ScriptRunner {
       throw new Error(`Analysis operation '${operation.type}' should be handled by executeAnalysisPipeline`);
     }
 
-    // Legacy custom operations not supported
-    if (operation.type === 'custom') {
-      throw new Error('Custom operations are not supported. Use built-in operations instead.');
-    }
-
     // Initialize indexer if needed
     if (!this.indexer) {
       throw new Error('Indexer not initialized');
@@ -529,14 +523,6 @@ export class ScriptRunner {
     // Analysis operations don't have preview
     if (operation.type === 'analyze' || operation.type === 'transform' || operation.type === 'aggregate') {
       return { details: { preview: true, operation: operation.type } };
-    }
-
-    // Legacy custom operations not supported
-    if (operation.type === 'custom') {
-      return {
-        skipped: true,
-        reason: 'Custom operations are not supported'
-      };
     }
 
     // Initialize indexer if needed

--- a/packages/vault/src/index.ts
+++ b/packages/vault/src/index.ts
@@ -17,7 +17,7 @@ export type {
   VaultContext,
   Document,
   DocumentSet,
-  Query,
+  QueryInput,
   ExecutionResult,
   Operation,
 } from '@mmt/entities';

--- a/packages/vault/src/vault-operations.ts
+++ b/packages/vault/src/vault-operations.ts
@@ -8,7 +8,7 @@ import type {
   VaultContext, 
   Document, 
   DocumentSet,
-  Query,
+  QueryInput,
   StructuredQuery,
   VaultIndex,
 } from '@mmt/entities';
@@ -186,7 +186,7 @@ class VaultContextImpl implements VaultContext {
    * @returns New context with matching documents
    * @example vault.select({ 'fs:path': 'posts/**', 'fm:status': 'draft' })
    */
-  select(query: Query): VaultContext {
+  select(query: QueryInput): VaultContext {
     const structured = parseQuery(query);
     const documents = Array.from(this.vault.documents.values());
     const filtered = documents.filter(doc => matchesQuery(doc, structured, this.vault.basePath));

--- a/tools/generate-operations-report.ts
+++ b/tools/generate-operations-report.ts
@@ -40,7 +40,7 @@ async function findOperations(): Promise<Operation[]> {
   const schemaContent = readFileSync(schemaPath, 'utf-8');
   
   // Extract operation types from schema
-  const operationTypes = ['move', 'rename', 'updateFrontmatter', 'delete', 'custom'];
+  const operationTypes = ['move', 'rename', 'updateFrontmatter', 'delete'];
   
   // Check scripting package for implementations
   const scriptRunnerPath = join(__dirname, '../packages/scripting/src/script-runner.ts');
@@ -62,7 +62,7 @@ async function findOperations(): Promise<Operation[]> {
       package: '@mmt/scripting',
       file: 'packages/scripting/src/script-runner.ts',
       line: 0, // Would need AST parsing for exact line
-      implemented: isImplemented && opType === 'custom', // Only custom is implemented
+      implemented: isImplemented,
       tested: testFiles.length > 0,
       testFiles,
     });
@@ -123,7 +123,6 @@ function getOperationDescription(opType: string): string {
     rename: 'Rename documents',
     updateFrontmatter: 'Update document frontmatter fields',
     delete: 'Delete documents',
-    custom: 'Execute custom operations',
   };
   return descriptions[opType] || 'Unknown operation';
 }


### PR DESCRIPTION
## Summary
- Removed all backward compatibility code per Issue #59
- Updated all imports and references to use non-deprecated types
- Ensured build passes with all changes

## Changes Made
1. **Entities Package**
   - Removed `QuerySchema` and `Query` deprecated aliases
   - Removed schemas backward compatibility export
   - Removed 'custom' from `OperationTypeSchema` enum

2. **Analysis Pipeline**
   - Removed deprecated `documentsToTable` and `tableToDocumentSet` exports
   - Removed legacy support from analysis-runner.ts

3. **Script Runner**
   - Removed legacy custom operations checks
   - Updated operation type checks to exclude 'custom'

4. **CLI Parser**
   - Changed to error on unknown flags instead of ignoring them

5. **Package Updates**
   - Updated all imports from `Query` to `QueryInput` in vault, document-set packages
   - Updated tools/generate-operations-report.ts to remove custom operations

## Test Plan
- [x] Build passes: `pnpm build` ✅
- [x] All backward compatibility code removed
- [ ] Lint errors exist but are unrelated to backward compatibility removal

## Breaking Changes
This is a breaking change that removes all backward compatibility code:
- Applications must use `QueryInput` instead of `Query`
- Custom operations are no longer supported
- Unknown CLI flags will now cause errors instead of being ignored

🤖 Generated with [Claude Code](https://claude.ai/code)