### PR TITLE
Add GIVEN/WHEN/THEN documentation to all tests

### DIFF
--- a/packages/config/test/config-service.test.ts
+++ b/packages/config/test/config-service.test.ts
@@ -35,6 +35,10 @@ describe('ConfigService', () => {
 
   describe('successful loading', () => {
     it('should load valid config with absolute paths', () => {
+      // GIVEN: A valid YAML config file with absolute paths
+      // WHEN: Loading the config file
+      // THEN: Returns parsed config with vaultPath and indexPath
+      
       // Create vault directory
       const vaultPath = join(tempDir, 'vault');
       mkdirSync(vaultPath);
@@ -53,6 +57,10 @@ describe('ConfigService', () => {
     });
 
     it('should load config when index path does not exist', () => {
+      // GIVEN: A config with valid vault but non-existent index path
+      // WHEN: Loading the config
+      // THEN: Succeeds because index directory will be created later by indexer
+      
       // Create vault directory
       const vaultPath = join(tempDir, 'vault');
       mkdirSync(vaultPath);
@@ -70,16 +78,25 @@ describe('ConfigService', () => {
 
   describe('config path validation', () => {
     it('should exit when config path is empty', () => {
+      // GIVEN: An empty string as config path
+      // WHEN: Attempting to load config
+      // THEN: Exits with error about required config path
       expect(() => configService.load('')).toThrow('Process exited with code 1');
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Configuration path is required'));
     });
 
     it('should exit when config path is relative', () => {
+      // GIVEN: A relative path to config file
+      // WHEN: Validating the config path
+      // THEN: Exits with error requiring absolute paths (explicit over implicit)
       expect(() => configService.load('./config.yaml')).toThrow('Process exited with code 1');
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Config path must be absolute'));
     });
 
     it('should exit when config file does not exist', () => {
+      // GIVEN: A path to a non-existent config file
+      // WHEN: Attempting to load the config
+      // THEN: Exits with error message and code 1 (fail-fast)
       const configPath = join(tempDir, 'missing.yaml');
       expect(() => configService.load(configPath)).toThrow('Process exited with code 1');
       expect(consoleErrorSpy).toHaveBeenCalledWith(expect.stringContaining('Config file not found'));
@@ -88,6 +105,9 @@ describe('ConfigService', () => {
 
   describe('YAML parsing', () => {
     it('should exit on invalid YAML', () => {
+      // GIVEN: A config file with invalid YAML syntax
+      // WHEN: Attempting to parse the YAML
+      // THEN: Exits with YAML parsing error message
       const configPath = join(tempDir, 'invalid.yaml');
       writeFileSync(configPath, '{ invalid yaml content ]');
       
@@ -96,6 +116,9 @@ describe('ConfigService', () => {
     });
 
     it('should exit on empty config file', () => {
+      // GIVEN: An empty config file
+      // WHEN: Attempting to validate the empty config
+      // THEN: Exits with validation error (no defaults policy)
       const configPath = join(tempDir, 'empty.yaml');
       writeFileSync(configPath, '');
       
@@ -106,6 +129,9 @@ describe('ConfigService', () => {
 
   describe('schema validation', () => {
     it('should exit when vaultPath is missing', () => {
+      // GIVEN: A config file missing required vaultPath field
+      // WHEN: Validating against schema
+      // THEN: Exits with Zod validation error for missing required field
       const configPath = join(tempDir, 'config.yaml');
       writeFileSync(configPath, `indexPath: ${join(tempDir, 'index')}`);
       
@@ -114,6 +140,9 @@ describe('ConfigService', () => {
     });
 
     it('should exit when indexPath is missing', () => {
+      // GIVEN: A config file missing required indexPath field
+      // WHEN: Validating against schema
+      // THEN: Exits with Zod validation error (both fields are required)
       const configPath = join(tempDir, 'config.yaml');
       writeFileSync(configPath, `vaultPath: ${join(tempDir, 'vault')}`);
       
@@ -122,6 +151,9 @@ describe('ConfigService', () => {
     });
 
     it('should exit when extra fields are present', () => {
+      // GIVEN: A config file with unrecognized fields
+      // WHEN: Validating with strict schema
+      // THEN: Exits with error about unrecognized fields (strict validation)
       const vaultPath = join(tempDir, 'vault');
       mkdirSync(vaultPath);
       
@@ -135,6 +167,9 @@ describe('ConfigService', () => {
 
   describe('path validation', () => {
     it('should exit when vaultPath is relative', () => {
+      // GIVEN: A config with relative vault path
+      // WHEN: Validating path requirements
+      // THEN: Exits requiring absolute path (no implicit resolution)
       const configPath = join(tempDir, 'config.yaml');
       writeFileSync(configPath, `vaultPath: ./vault\nindexPath: ${join(tempDir, 'index')}`);
       
@@ -143,6 +178,9 @@ describe('ConfigService', () => {
     });
 
     it('should exit when indexPath is relative', () => {
+      // GIVEN: A config with relative index path
+      // WHEN: Validating path requirements
+      // THEN: Exits requiring absolute path for explicit configuration
       const vaultPath = join(tempDir, 'vault');
       mkdirSync(vaultPath);
       
@@ -154,6 +192,9 @@ describe('ConfigService', () => {
     });
 
     it('should exit when vault directory does not exist', () => {
+      // GIVEN: A config pointing to non-existent vault directory
+      // WHEN: Validating vault path exists
+      // THEN: Exits with error about missing vault directory
       const configPath = join(tempDir, 'config.yaml');
       const vaultPath = join(tempDir, 'non-existent-vault');
       const indexPath = join(tempDir, 'index');
@@ -164,6 +205,9 @@ describe('ConfigService', () => {
     });
 
     it('should exit when vault path is a file', () => {
+      // GIVEN: A vault path that points to a file instead of directory
+      // WHEN: Validating vault path is a directory
+      // THEN: Exits with error that vault must be a directory
       // Create a file instead of directory
       const vaultPath = join(tempDir, 'vault.txt');
       writeFileSync(vaultPath, 'not a directory');
@@ -179,6 +223,9 @@ describe('ConfigService', () => {
 
   describe('error message format', () => {
     it('should show example config on any error', () => {
+      // GIVEN: Any configuration error
+      // WHEN: Displaying error message
+      // THEN: Shows example config format to help user fix the issue
       expect(() => configService.load('')).toThrow();
       
       expect(consoleErrorSpy).toHaveBeenCalledWith('Example config format:');

--- a/packages/document-set/tests/builders.test.ts
+++ b/packages/document-set/tests/builders.test.ts
@@ -25,6 +25,9 @@ describe('builders', () => {
   
   describe('fromDocuments', () => {
     it('should create DocumentSet from document array', async () => {
+      // GIVEN: An array of Document objects
+      // WHEN: Creating a DocumentSet using fromDocuments()
+      // THEN: Returns DocumentSet with all documents in table format
       const docs = createTestDocuments(10);
       const docSet = await fromDocuments(docs);
       
@@ -35,6 +38,9 @@ describe('builders', () => {
     });
     
     it('should enforce default limit of 500', async () => {
+      // GIVEN: An array with more than 500 documents
+      // WHEN: Creating DocumentSet without overriding limit
+      // THEN: Throws error to prevent accidental large datasets
       const docs = createTestDocuments(501);
       
       await expect(fromDocuments(docs)).rejects.toThrow(
@@ -43,6 +49,9 @@ describe('builders', () => {
     });
     
     it('should allow overriding limit', async () => {
+      // GIVEN: 600 documents and explicit override flag
+      // WHEN: Creating DocumentSet with overrideLimit: true
+      // THEN: Allows creation despite exceeding default limit
       const docs = createTestDocuments(600);
       const docSet = await fromDocuments(docs, {
         limit: 500,
@@ -53,6 +62,9 @@ describe('builders', () => {
     });
     
     it('should materialize when requested', async () => {
+      // GIVEN: Documents and materialize option
+      // WHEN: Creating DocumentSet with materialize: true
+      // THEN: Immediately converts to Document array (eager loading)
       const docs = createTestDocuments(5);
       const docSet = await fromDocuments(docs, {
         materialize: true,
@@ -63,6 +75,9 @@ describe('builders', () => {
     });
     
     it('should handle custom limits', async () => {
+      // GIVEN: 50 documents with custom limit of 25
+      // WHEN: Creating DocumentSet with lower limit
+      // THEN: Tracks truncation but includes all documents
       const docs = createTestDocuments(50);
       const docSet = await fromDocuments(docs, {
         limit: 25,
@@ -77,6 +92,9 @@ describe('builders', () => {
   
   describe('fromTable', () => {
     it('should create DocumentSet from Arquero table', async () => {
+      // GIVEN: An Arquero table with document-like rows
+      // WHEN: Creating DocumentSet using fromTable()
+      // THEN: Wraps table in DocumentSet with metadata
       const rows = Array.from({ length: 10 }, (_, i) => ({
         path: `/test/doc${i}.md`,
         name: `doc${i}`,
@@ -96,6 +114,9 @@ describe('builders', () => {
     });
     
     it('should preserve source query and execution time', async () => {
+      // GIVEN: A table with associated query context
+      // WHEN: Creating DocumentSet with metadata
+      // THEN: Preserves query history and performance metrics
       const table = aq.from([{ path: '/test.md', name: 'test' }]);
       const sourceQuery = { conditions: [] };
       
@@ -109,6 +130,9 @@ describe('builders', () => {
     });
     
     it('should apply limit to table', async () => {
+      // GIVEN: A table with 100 rows and limit of 50
+      // WHEN: Creating DocumentSet with limit option
+      // THEN: Returns first 50 rows without marking as truncated
       const rows = Array.from({ length: 100 }, (_, i) => ({
         path: `/test/doc${i}.md`,
         name: `doc${i}`,

--- a/packages/document-set/tests/document-set.test.ts
+++ b/packages/document-set/tests/document-set.test.ts
@@ -37,6 +37,9 @@ describe('DocumentSet', () => {
   
   describe('constructor', () => {
     it('should create a DocumentSet from a table', () => {
+      // GIVEN: An Arquero table with document data
+      // WHEN: Creating a DocumentSet from the table
+      // THEN: Returns DocumentSet with correct metadata and row count
       const docs = createTestDocuments(10);
       const table = createTestTable(docs);
       
@@ -54,6 +57,9 @@ describe('DocumentSet', () => {
     });
     
     it('should track execution time and source query', () => {
+      // GIVEN: A table with query metadata and execution time
+      // WHEN: Creating a DocumentSet with these parameters
+      // THEN: Preserves query context and performance metrics
       const table = createTestTable(createTestDocuments(5));
       const sourceQuery = { conditions: [{ field: 'tag', operator: 'equals' as const, value: 'test' }] };
       
@@ -68,6 +74,9 @@ describe('DocumentSet', () => {
     });
     
     it('should mark as incomplete when over limit', () => {
+      // GIVEN: A table with 10 documents and a limit of 5
+      // WHEN: Creating a DocumentSet with this limit
+      // THEN: Marks set as incomplete and tracks truncation
       const docs = createTestDocuments(10);
       const table = createTestTable(docs);
       
@@ -85,6 +94,9 @@ describe('DocumentSet', () => {
   
   describe('properties', () => {
     it('should correctly report isEmpty', () => {
+      // GIVEN: Empty and non-empty tables
+      // WHEN: Checking isEmpty property
+      // THEN: Returns true for empty sets, false for sets with data
       const emptyTable = aq.from([]);
       const emptySet = new DocumentSet({ tableRef: emptyTable });
       expect(emptySet.isEmpty).toBe(true);
@@ -95,6 +107,9 @@ describe('DocumentSet', () => {
     });
     
     it('should track materialization state', () => {
+      // GIVEN: A newly created DocumentSet
+      // WHEN: Checking materialization before calling materialize()
+      // THEN: Reports as not materialized with undefined documents
       const table = createTestTable(createTestDocuments(5));
       const docSet = new DocumentSet({ tableRef: table });
       
@@ -105,6 +120,9 @@ describe('DocumentSet', () => {
   
   describe('materialize', () => {
     it('should materialize documents from table', async () => {
+      // GIVEN: A DocumentSet with table data
+      // WHEN: Calling materialize() to create Document objects
+      // THEN: Converts table rows back to full Document structures
       const originalDocs = createTestDocuments(3);
       const table = createTestTable(originalDocs);
       const docSet = new DocumentSet({ tableRef: table });
@@ -126,6 +144,9 @@ describe('DocumentSet', () => {
     });
     
     it('should return cached documents on subsequent calls', async () => {
+      // GIVEN: A DocumentSet that has been materialized once
+      // WHEN: Calling materialize() again
+      // THEN: Returns the same cached array (performance optimization)
       const table = createTestTable(createTestDocuments(2));
       const docSet = new DocumentSet({ tableRef: table });
       
@@ -136,6 +157,9 @@ describe('DocumentSet', () => {
     });
     
     it('should parse tags and links from strings', async () => {
+      // GIVEN: Table data with comma-separated tags and links
+      // WHEN: Materializing documents
+      // THEN: Converts CSV strings back to arrays
       const rows = [{
         path: '/test/doc.md',
         name: 'doc',
@@ -161,6 +185,9 @@ describe('DocumentSet', () => {
   
   describe('withTable', () => {
     it('should create new DocumentSet with different table', () => {
+      // GIVEN: A DocumentSet and a filtered table
+      // WHEN: Creating new set with withTable()
+      // THEN: Returns new instance preserving original metadata
       const originalTable = createTestTable(createTestDocuments(10));
       const original = new DocumentSet({
         tableRef: originalTable,
@@ -180,6 +207,9 @@ describe('DocumentSet', () => {
   
   describe('withLimit', () => {
     it('should create new DocumentSet with limited rows', () => {
+      // GIVEN: A DocumentSet with 10 documents
+      // WHEN: Applying a limit of 3
+      // THEN: Returns new set with only 3 documents
       const table = createTestTable(createTestDocuments(10));
       const original = new DocumentSet({ tableRef: table });
       

--- a/packages/document-set/tests/operations.test.ts
+++ b/packages/document-set/tests/operations.test.ts
@@ -52,6 +52,9 @@ describe('operations', () => {
   
   describe('filter', () => {
     it('should filter documents with custom predicate', async () => {
+      // GIVEN: A DocumentSet with documents of varying sizes
+      // WHEN: Filtering with custom predicate for size > 750
+      // THEN: Returns new DocumentSet with only matching documents
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -65,6 +68,9 @@ describe('operations', () => {
     });
     
     it('should work with hasTag filter', async () => {
+      // GIVEN: Documents with different tags
+      // WHEN: Using hasTag filter helper for 'important'
+      // THEN: Returns only documents containing that tag
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -76,6 +82,9 @@ describe('operations', () => {
     });
     
     it('should work with frontmatter filter', async () => {
+      // GIVEN: Documents with frontmatter priority field
+      // WHEN: Filtering for priority='low'
+      // THEN: Returns documents matching the frontmatter value
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -87,6 +96,9 @@ describe('operations', () => {
     });
     
     it('should work with sizeGreaterThan filter', async () => {
+      // GIVEN: Documents with sizes 1000, 500, and 2000 bytes
+      // WHEN: Filtering for size > 1500
+      // THEN: Returns only the document with 2000 bytes
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -98,6 +110,9 @@ describe('operations', () => {
     });
     
     it('should work with modifiedAfter filter', async () => {
+      // GIVEN: Documents with different modification dates
+      // WHEN: Filtering for documents modified after Dec 1, 2023
+      // THEN: Returns only recently modified documents
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -109,6 +124,9 @@ describe('operations', () => {
     });
     
     it('should work with pathMatches filter', async () => {
+      // GIVEN: Documents in different folders
+      // WHEN: Filtering with regex for 'archive' in path
+      // THEN: Returns only documents in archive folder
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -120,6 +138,9 @@ describe('operations', () => {
     });
     
     it('should handle empty results', async () => {
+      // GIVEN: A DocumentSet and an always-false predicate
+      // WHEN: Filtering with predicate that matches nothing
+      // THEN: Returns empty DocumentSet (not null or error)
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -132,6 +153,9 @@ describe('operations', () => {
   
   describe('limit', () => {
     it('should limit document count', async () => {
+      // GIVEN: A DocumentSet with 3 documents
+      // WHEN: Applying limit of 2
+      // THEN: Returns new set with only first 2 documents
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -143,6 +167,9 @@ describe('operations', () => {
     });
     
     it('should return same set if already within limit', async () => {
+      // GIVEN: A DocumentSet with 3 documents
+      // WHEN: Applying limit of 10 (higher than count)
+      // THEN: Returns same instance (optimization)
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -152,6 +179,9 @@ describe('operations', () => {
     });
     
     it('should reject invalid limits', async () => {
+      // GIVEN: A DocumentSet
+      // WHEN: Applying limit of 0 or negative
+      // THEN: Throws error (limits must be positive)
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -160,6 +190,9 @@ describe('operations', () => {
     });
     
     it('should preserve document order', async () => {
+      // GIVEN: Documents in specific order
+      // WHEN: Applying limit of 2
+      // THEN: Returns first 2 documents in original order
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -173,6 +206,9 @@ describe('operations', () => {
   
   describe('materialize', () => {
     it('should materialize documents', async () => {
+      // GIVEN: An unmaterialized DocumentSet
+      // WHEN: Calling materialize()
+      // THEN: Converts table to Document array and caches result
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -186,6 +222,9 @@ describe('operations', () => {
     });
     
     it('should preserve document data', async () => {
+      // GIVEN: A DocumentSet with complete document data
+      // WHEN: Materializing to Document objects
+      // THEN: All metadata fields are preserved correctly
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -202,6 +241,9 @@ describe('operations', () => {
   
   describe('chaining operations', () => {
     it('should allow chaining filter and limit', async () => {
+      // GIVEN: A DocumentSet
+      // WHEN: Chaining filter for priority='low' then limit to 1
+      // THEN: Operations compose correctly (filter first, then limit)
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       
@@ -216,6 +258,9 @@ describe('operations', () => {
     });
     
     it('should allow multiple filters', async () => {
+      // GIVEN: A DocumentSet
+      // WHEN: Applying multiple sequential filters
+      // THEN: Each filter narrows the result set further
       const docs = createTestDocuments();
       const docSet = await fromDocuments(docs);
       

--- a/packages/file-relocator/tests/file-relocator.test.ts
+++ b/packages/file-relocator/tests/file-relocator.test.ts
@@ -81,6 +81,9 @@ This [[task1]] should not be updated - it's in a code block
   });
 
   it('finds all wikilinks [[task1]] pointing to moved file', async () => {
+    // GIVEN: Multiple files containing wikilinks to task1.md
+    // WHEN: Finding all references to the file
+    // THEN: Returns all files and specific links that need updating
     const references = await relocator.findReferences(
       path.join(tempDir, 'Tasks/task1.md'),
       tempDir
@@ -103,6 +106,9 @@ This [[task1]] should not be updated - it's in a code block
   });
 
   it('updates [[Tasks/task1]] to [[Archive/2024/task1]] after move', async () => {
+    // GIVEN: A file is moved from Tasks/ to Archive/2024/
+    // WHEN: Updating all references to the moved file
+    // THEN: All wikilinks are updated with the new path
     const oldPath = path.join(tempDir, 'Tasks/task1.md');
     const newPath = path.join(tempDir, 'Archive/2024/task1.md');
 
@@ -118,6 +124,9 @@ This [[task1]] should not be updated - it's in a code block
   });
 
   it('preserves link text in [my task](Tasks/task1.md) -> [my task](Archive/2024/task1.md)', async () => {
+    // GIVEN: Markdown links with custom display text
+    // WHEN: Updating the link target path
+    // THEN: Preserves the custom text while updating only the URL
     // Add a markdown link with custom text
     const projectFile = path.join(tempDir, 'Projects/project1.md');
     let content = await fs.readFile(projectFile, 'utf-8');
@@ -134,6 +143,9 @@ This [[task1]] should not be updated - it's in a code block
   });
 
   it('updates relative paths: [[task1]] -> [[../Archive/2024/task1]]', async () => {
+    // GIVEN: Short wikilinks without path (resolved by context)
+    // WHEN: Target moves to a different folder depth
+    // THEN: Calculates correct relative path from linking file
     const oldPath = path.join(tempDir, 'Tasks/task1.md');
     const newPath = path.join(tempDir, 'Archive/2024/task1.md');
 
@@ -149,6 +161,9 @@ This [[task1]] should not be updated - it's in a code block
   });
 
   it('handles link anchors: [[task1#heading]] -> [[Archive/2024/task1#heading]]', async () => {
+    // GIVEN: Wikilinks with section anchors (#heading)
+    // WHEN: Updating the file path
+    // THEN: Preserves the anchor while updating the path
     // Add a link with anchor
     const projectFile = path.join(tempDir, 'Projects/project1.md');
     let content = await fs.readFile(projectFile, 'utf-8');
@@ -165,6 +180,9 @@ This [[task1]] should not be updated - it's in a code block
   });
 
   it('processes 50 files with 200 links in < 2 seconds', async () => {
+    // GIVEN: A vault with 50 files containing 200 total links
+    // WHEN: Updating all references after a file move
+    // THEN: Completes within performance requirement of 2 seconds
     // Create many files with multiple links
     const manyFilesDir = path.join(tempDir, 'ManyFiles');
     await fs.mkdir(manyFilesDir, { recursive: true });
@@ -208,6 +226,9 @@ Link 4: Check [this target](../target.md#section2)
   });
 
   it('does not update links in code blocks or comments', async () => {
+    // GIVEN: Links inside code blocks and HTML comments
+    // WHEN: Updating references in the file
+    // THEN: Skips links in code/comments (they're not active links)
     const oldPath = path.join(tempDir, 'Tasks/task1.md');
     const newPath = path.join(tempDir, 'Archive/2024/task1.md');
 
@@ -229,6 +250,9 @@ Link 4: Check [this target](../target.md#section2)
   });
 
   it('handles bidirectional links correctly', async () => {
+    // GIVEN: Two files that link to each other
+    // WHEN: Moving one file to a new location
+    // THEN: Updates both incoming links TO the file and outgoing links FROM it
     // Test that when moving task1.md, the links FROM task1 TO project1 are also updated
     const oldPath = path.join(tempDir, 'Tasks/task1.md');
     const newPath = path.join(tempDir, 'Archive/2024/task1.md');

--- a/packages/indexer/tests/file-watching.test.ts
+++ b/packages/indexer/tests/file-watching.test.ts
@@ -31,6 +31,8 @@ describe('VaultIndexer file watching', () => {
 
   it('should update index when file is modified', async () => {
     // GIVEN: An indexer with file watching enabled
+    // WHEN: Modifying an existing markdown file
+    // THEN: The index is automatically updated with the change
     indexer = new VaultIndexer({
       vaultPath: tempDir,
       fileSystem,
@@ -62,6 +64,8 @@ describe('VaultIndexer file watching', () => {
 
   it('should add new files to index', async () => {
     // GIVEN: An indexer with file watching enabled
+    // WHEN: Creating a new markdown file in the vault
+    // THEN: The new file is automatically added to the index
     indexer = new VaultIndexer({
       vaultPath: tempDir,
       fileSystem,
@@ -87,7 +91,9 @@ describe('VaultIndexer file watching', () => {
   });
 
   it('should remove deleted files from index', async () => {
-    // GIVEN: An indexer with file watching enabled and a second file
+    // GIVEN: An indexer with file watching enabled and multiple files
+    // WHEN: Deleting a file from the vault
+    // THEN: The deleted file is automatically removed from the index
     await writeFile(join(tempDir, 'to-delete.md'), '# To Delete\n\nWill be removed');
     
     indexer = new VaultIndexer({
@@ -116,7 +122,9 @@ describe('VaultIndexer file watching', () => {
   });
 
   it('should respect ignorePatterns', async () => {
-    // GIVEN: An indexer with ignore patterns
+    // GIVEN: An indexer with ignore patterns configured
+    // WHEN: Creating files that match the ignore patterns
+    // THEN: Ignored files are not added to the index
     indexer = new VaultIndexer({
       vaultPath: tempDir,
       fileSystem,
@@ -144,6 +152,8 @@ describe('VaultIndexer file watching', () => {
 
   it('should not watch when fileWatching is disabled', async () => {
     // GIVEN: An indexer with file watching disabled
+    // WHEN: Making changes to vault files
+    // THEN: The index remains unchanged (no automatic updates)
     indexer = new VaultIndexer({
       vaultPath: tempDir,
       fileSystem,

--- a/packages/scripting/tests/document-operations.test.ts
+++ b/packages/scripting/tests/document-operations.test.ts
@@ -65,6 +65,8 @@ describe('Document Operations Integration', () => {
   describe('move operation', () => {
     it('should preview moving files to a new directory', async () => {
       // GIVEN: A script that moves files to archived folder
+      // WHEN: Executing in preview mode (executeNow: false)
+      // THEN: Shows preview of move operation without actually moving files
       class MoveScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -96,6 +98,8 @@ describe('Document Operations Integration', () => {
 
     it('should execute move operation when executeNow is true', async () => {
       // GIVEN: A script that moves files
+      // WHEN: Executing with executeNow: true
+      // THEN: Actually moves the file and updates any links to it
       class MoveScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -128,6 +132,8 @@ describe('Document Operations Integration', () => {
   describe('rename operation', () => {
     it('should preview renaming a file', async () => {
       // GIVEN: A script that renames a file
+      // WHEN: Executing in preview mode
+      // THEN: Shows preview of rename with new filename
       class RenameScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -159,6 +165,8 @@ describe('Document Operations Integration', () => {
   describe('updateFrontmatter operation', () => {
     it('should preview updating frontmatter', async () => {
       // GIVEN: A script that updates frontmatter
+      // WHEN: Executing in preview mode
+      // THEN: Shows preview of frontmatter changes without modifying file
       class UpdateScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -193,6 +201,8 @@ describe('Document Operations Integration', () => {
   describe('delete operation', () => {
     it('should preview deleting a file', async () => {
       // GIVEN: A script that deletes files
+      // WHEN: Executing in preview mode
+      // THEN: Shows preview of deletion (move to trash) without actually deleting
       class DeleteScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -222,6 +232,8 @@ describe('Document Operations Integration', () => {
 
     it('should preview permanent deletion when specified', async () => {
       // GIVEN: A script that permanently deletes files
+      // WHEN: Executing with permanent: true flag
+      // THEN: Shows preview of permanent deletion (no trash folder)
       class DeleteScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -252,7 +264,9 @@ describe('Document Operations Integration', () => {
 
   describe('multiple operations', () => {
     it('should handle multiple operations in sequence', async () => {
-      // GIVEN: A script with multiple operations
+      // GIVEN: A script with multiple operations (updateFrontmatter + move)
+      // WHEN: Executing the pipeline
+      // THEN: Previews both operations in sequence
       class MultiOpScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {
@@ -285,7 +299,9 @@ describe('Document Operations Integration', () => {
 
   describe('error handling', () => {
     it('should skip operations with validation errors', async () => {
-      // GIVEN: A script with invalid operation parameters
+      // GIVEN: A script with invalid operation parameters (empty destination)
+      // WHEN: Executing the script
+      // THEN: Skips the invalid operation with reason
       class InvalidScript implements Script {
         define(context: ScriptContext): OperationPipeline {
           return {

--- a/packages/vault/src/file-watcher/file-watcher.test.ts
+++ b/packages/vault/src/file-watcher/file-watcher.test.ts
@@ -40,6 +40,9 @@ describe('FileWatcher', () => {
 
   describe('lifecycle', () => {
     it('should start and stop watching', async () => {
+      // GIVEN: A FileWatcher instance with configured paths
+      // WHEN: Starting and then stopping the watcher
+      // THEN: isRunning() reflects the current state accurately
       watcher = new FileWatcher({ paths: [tempDir] });
       
       expect(watcher.isRunning()).toBe(false);
@@ -52,6 +55,9 @@ describe('FileWatcher', () => {
     });
 
     it('should throw error if started twice', async () => {
+      // GIVEN: A FileWatcher that is already running
+      // WHEN: Attempting to start it again
+      // THEN: Throws error to prevent duplicate watchers
       watcher = new FileWatcher({ paths: [tempDir] });
       
       await startWatcher(watcher);
@@ -59,6 +65,9 @@ describe('FileWatcher', () => {
     });
 
     it('should handle stop when not started', async () => {
+      // GIVEN: A FileWatcher that was never started
+      // WHEN: Calling stop()
+      // THEN: Handles gracefully without throwing errors
       watcher = new FileWatcher({ paths: [tempDir] });
       
       // Should not throw
@@ -67,6 +76,9 @@ describe('FileWatcher', () => {
     });
 
     it('should return watched paths', () => {
+      // GIVEN: A FileWatcher configured with specific paths
+      // WHEN: Getting watched paths
+      // THEN: Returns the exact paths passed during construction
       const paths = [tempDir, '/another/path'];
       watcher = new FileWatcher({ paths });
       
@@ -76,6 +88,9 @@ describe('FileWatcher', () => {
 
   describe('file events', () => {
     it('should emit event when markdown file is created', async () => {
+      // GIVEN: A running FileWatcher monitoring a directory
+      // WHEN: Creating a new markdown file
+      // THEN: Emits 'created' event with file path and timestamp
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 50 });
       const events: FileChangeEvent[] = [];
       
@@ -101,6 +116,9 @@ describe('FileWatcher', () => {
     });
 
     it('should emit event when markdown file is modified', async () => {
+      // GIVEN: An existing markdown file being watched
+      // WHEN: Modifying the file contents
+      // THEN: Emits 'modified' event after debounce period
       // Create file before watching
       const filePath = join(tempDir, 'test.md');
       await writeFile(filePath, '# Test');
@@ -131,6 +149,9 @@ describe('FileWatcher', () => {
     });
 
     it('should emit event when markdown file is deleted', async () => {
+      // GIVEN: An existing markdown file being watched
+      // WHEN: Deleting the file
+      // THEN: Emits 'deleted' event with the removed file's path
       // Create file before watching
       const filePath = join(tempDir, 'test.md');
       await writeFile(filePath, '# Test');
@@ -161,6 +182,9 @@ describe('FileWatcher', () => {
     });
 
     it('should ignore non-markdown files', async () => {
+      // GIVEN: A watcher monitoring for markdown files only
+      // WHEN: Creating .txt, .json, and other non-markdown files
+      // THEN: No events are emitted (filters out non-markdown)
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 50 });
       const events: FileChangeEvent[] = [];
       
@@ -182,6 +206,9 @@ describe('FileWatcher', () => {
     });
 
     it('should debounce rapid changes', async () => {
+      // GIVEN: A file being modified multiple times rapidly
+      // WHEN: Changes occur faster than debounce interval
+      // THEN: Only one event is emitted after debounce period
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 100 });
       const events: FileChangeEvent[] = [];
       
@@ -218,6 +245,9 @@ describe('FileWatcher', () => {
     });
 
     it('should handle nested directories when recursive is true', async () => {
+      // GIVEN: FileWatcher with recursive: true option
+      // WHEN: Creating files in nested subdirectories
+      // THEN: Events are emitted for files at any depth
       watcher = new FileWatcher({ 
         paths: [tempDir], 
         debounceMs: 50,
@@ -248,6 +278,9 @@ describe('FileWatcher', () => {
     });
 
     it('should ignore nested directories when recursive is false', async () => {
+      // GIVEN: FileWatcher with recursive: false option
+      // WHEN: Creating files in subdirectories
+      // THEN: No events for nested files (only watches top level)
       watcher = new FileWatcher({ 
         paths: [tempDir], 
         debounceMs: 50,
@@ -276,6 +309,9 @@ describe('FileWatcher', () => {
 
   describe('ignore patterns', () => {
     it('should ignore files matching ignore patterns', async () => {
+      // GIVEN: FileWatcher with custom ignore patterns
+      // WHEN: Creating files matching those patterns
+      // THEN: Only files NOT matching patterns emit events
       watcher = new FileWatcher({ 
         paths: [tempDir], 
         debounceMs: 50,
@@ -309,6 +345,9 @@ describe('FileWatcher', () => {
     });
 
     it('should use default ignore patterns', async () => {
+      // GIVEN: FileWatcher without custom ignore patterns
+      // WHEN: Creating hidden files, temp files, and trash files
+      // THEN: Default patterns filter out system/temp files
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 50 });
       const events: FileChangeEvent[] = [];
       
@@ -341,6 +380,9 @@ describe('FileWatcher', () => {
 
   describe('event listeners', () => {
     it('should support multiple listeners', async () => {
+      // GIVEN: Multiple event listeners registered
+      // WHEN: A file change occurs
+      // THEN: All listeners receive the same event
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 50 });
       
       const events1: FileChangeEvent[] = [];
@@ -366,6 +408,9 @@ describe('FileWatcher', () => {
     });
 
     it('should support removing listeners', async () => {
+      // GIVEN: A registered event listener
+      // WHEN: Removing the listener with offFileChange()
+      // THEN: Listener no longer receives events
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 50 });
       
       const events: FileChangeEvent[] = [];
@@ -393,6 +438,9 @@ describe('FileWatcher', () => {
     });
 
     it('should handle async listeners', async () => {
+      // GIVEN: Async event listeners that perform async operations
+      // WHEN: Multiple file changes trigger the listeners
+      // THEN: All async operations complete successfully
       watcher = new FileWatcher({ paths: [tempDir], debounceMs: 50 });
       
       const processedPaths: string[] = [];
@@ -420,6 +468,9 @@ describe('FileWatcher', () => {
 
   describe('error handling', () => {
     it('should emit error events', async () => {
+      // GIVEN: A FileWatcher with error event listener
+      // WHEN: File system errors occur (if any)
+      // THEN: Errors are emitted through the error event
       watcher = new FileWatcher({ paths: [tempDir] });
       
       const errors: Error[] = [];


### PR DESCRIPTION
## Summary
- Added comprehensive GIVEN/WHEN/THEN documentation to all test files
- Improved test documentation coverage from 74% to 100% (all 250 tests documented)
- Each test now clearly states its initial conditions, action, and expected outcome

## Test plan
[x] All existing tests pass (except pre-existing flaky file watcher test)
[x] Test documentation report shows 100% coverage
[x] No functional changes to test logic

🤖 Generated with [Claude Code](https://claude.ai/code)