### PR TITLE
fix: implement proper search filtering in indexer (#115)

### DIFF
--- a/apps/api-server/src/routes/documents.ts
+++ b/apps/api-server/src/routes/documents.ts
@@ -21,14 +21,14 @@ export function documentsRouter(context: Context): Router {
         // Execute query
         // If no query provided, get all documents
         const results = q 
-          ? await context.indexer.query({
+          ? context.indexer.query({
               conditions: [{
                 field: 'content',
-                operator: 'contains',
+                operator: 'contains' as const,
                 value: q
               }]
             })
-          : await context.indexer.getAllDocuments();
+          : context.indexer.getAllDocuments();
         
         // Apply pagination
         const start = offset;

--- a/apps/api-server/tests/search-documents.test.js
+++ b/apps/api-server/tests/search-documents.test.js
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import request from 'supertest';
+import { createApp } from '../src/app.js';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { writeFileSync, mkdirSync } from 'fs';
+
+describe('API Documents search functionality', () => {
+  let app;
+  let testVaultPath;
+  let testIndexPath;
+  let tempDir;
+
+  beforeAll(async () => {
+    // Create real temp directories for testing
+    tempDir = mkdtempSync(join(tmpdir(), 'mmt-api-search-test-'));
+    testVaultPath = join(tempDir, 'vault');
+    testIndexPath = join(tempDir, 'index');
+    
+    mkdirSync(testVaultPath, { recursive: true });
+    mkdirSync(testIndexPath, { recursive: true });
+    
+    // Create test documents
+    writeFileSync(join(testVaultPath, 'alpha-guide.md'), `# Alpha Guide
+
+This is a comprehensive guide about alpha features.
+It contains detailed information about the alpha release.`);
+
+    writeFileSync(join(testVaultPath, 'beta-notes.md'), `# Beta Notes
+
+Notes about beta testing and beta features.
+No mention of the other Greek letter here.`);
+
+    writeFileSync(join(testVaultPath, 'release-notes.md'), `# Release Notes
+
+This document covers both alpha and beta releases.
+It's a general overview of all features.`);
+
+    writeFileSync(join(testVaultPath, 'readme.md'), `# Project README
+
+General project information.
+Nothing specific about alpha or beta.`);
+    
+    // Create app with test config
+    app = await createApp({
+      vaultPath: testVaultPath,
+      indexPath: testIndexPath
+    });
+  });
+
+  afterAll(() => {
+    // Clean up temp directory
+    rmSync(tempDir, { recursive: true });
+  });
+
+  it('should return all documents when no query is provided', async () => {
+    const response = await request(app)
+      .get('/api/documents')
+      .expect(200);
+    
+    expect(response.body.total).toBe(4);
+    expect(response.body.documents).toHaveLength(4);
+  });
+
+  it('should filter documents by search query', async () => {
+    const response = await request(app)
+      .get('/api/documents?q=alpha')
+      .expect(200);
+    
+    
+    // Should return only documents with "alpha" in their name/title
+    // Note: Since we don't index actual file content, we search in metadata
+    expect(response.body.total).toBe(1);
+    expect(response.body.documents).toHaveLength(1);
+    
+    const names = response.body.documents.map(d => d.metadata.name).sort();
+    expect(names).toEqual(['alpha-guide']);
+  });
+
+  it('should return empty results for non-matching query', async () => {
+    const response = await request(app)
+      .get('/api/documents?q=gamma')
+      .expect(200);
+    
+    expect(response.body.total).toBe(0);
+    expect(response.body.documents).toHaveLength(0);
+    expect(response.body.hasMore).toBe(false);
+  });
+
+  it('should be case insensitive', async () => {
+    const lowerResponse = await request(app)
+      .get('/api/documents?q=beta')
+      .expect(200);
+    
+    const upperResponse = await request(app)
+      .get('/api/documents?q=BETA')
+      .expect(200);
+    
+    expect(lowerResponse.body.total).toBe(upperResponse.body.total);
+    // Should match 'beta-notes' filename
+    expect(lowerResponse.body.total).toBe(1);
+  });
+
+  it('should handle partial matches', async () => {
+    const response = await request(app)
+      .get('/api/documents?q=alph')
+      .expect(200);
+    
+    // Should match "alpha-guide" filename
+    expect(response.body.total).toBe(1);
+  });
+
+  it('should properly paginate search results', async () => {
+    // Search for something that matches multiple files
+    const response = await request(app)
+      .get('/api/documents?q=notes&limit=2&offset=0');
+    
+    expect(response.status).toBe(200);
+    
+    // "notes" should match "beta-notes" and "release-notes"
+    expect(response.body.documents).toHaveLength(2);
+    expect(response.body.hasMore).toBe(false);
+  });
+
+  it('should handle special characters in query', async () => {
+    // Test that special regex characters are escaped
+    const response = await request(app)
+      .get('/api/documents?q=alpha.*')
+      .expect(200);
+    
+    // Should treat .* as literal characters, not regex
+    expect(response.body.total).toBe(0);
+  });
+
+  it('should return documents with proper metadata including modified field', async () => {
+    const response = await request(app)
+      .get('/api/documents?q=alpha')
+      .expect(200);
+    
+    expect(response.body.documents.length).toBeGreaterThan(0);
+    
+    for (const doc of response.body.documents) {
+      expect(doc.metadata).toHaveProperty('name');
+      expect(doc.metadata).toHaveProperty('modified');
+      expect(doc.metadata).toHaveProperty('size');
+      expect(doc.metadata).toHaveProperty('tags');
+      expect(doc.metadata).toHaveProperty('frontmatter');
+    }
+  });
+});

--- a/packages/entities/src/api-schemas.ts
+++ b/packages/entities/src/api-schemas.ts
@@ -5,8 +5,8 @@ import { z } from 'zod';
 // Documents API
 export const DocumentsQuerySchema = z.object({
   q: z.string().optional(),
-  limit: z.number().int().positive().max(1000).default(100),
-  offset: z.number().int().min(0).default(0),
+  limit: z.coerce.number().int().positive().max(1000).default(100),
+  offset: z.coerce.number().int().min(0).default(0),
   sortBy: z.enum(['name', 'modified', 'size']).optional(),
   sortOrder: z.enum(['asc', 'desc']).default('asc'),
 });

--- a/packages/indexer/src/query-executor.ts
+++ b/packages/indexer/src/query-executor.ts
@@ -118,9 +118,36 @@ export class QueryExecutor {
       case 'title':
         return this.compareValues(doc.title, operator, value);
       case 'content':
-        // For now, we don't have content in metadata
-        // This would require loading the file
-        return true;
+        // Since we don't store content in metadata, search across
+        // multiple text fields that users would expect to match
+        const searchValue = String(value).toLowerCase();
+        
+        // Search in title
+        if (doc.title.toLowerCase().includes(searchValue)) {
+          return true;
+        }
+        
+        // Search in basename
+        if (doc.basename.toLowerCase().includes(searchValue)) {
+          return true;
+        }
+        
+        // Search in path
+        if (doc.relativePath.toLowerCase().includes(searchValue)) {
+          return true;
+        }
+        
+        // Search in aliases
+        if (doc.aliases.some(alias => alias.toLowerCase().includes(searchValue))) {
+          return true;
+        }
+        
+        // Search in tags
+        if (doc.tags.some(tag => tag.toLowerCase().includes(searchValue))) {
+          return true;
+        }
+        
+        return false;
       default:
         return false;
     }

--- a/packages/indexer/tests/search-functionality.test.ts
+++ b/packages/indexer/tests/search-functionality.test.ts
@@ -1,0 +1,212 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { VaultIndexer } from '../src/vault-indexer.js';
+import { NodeFileSystem } from '@mmt/filesystem-access';
+
+describe('Indexer search functionality', () => {
+  let testVaultPath: string;
+  let indexer: VaultIndexer;
+  let fs: NodeFileSystem;
+
+  beforeEach(async () => {
+    // Create test vault
+    testVaultPath = mkdtempSync(join(tmpdir(), 'mmt-search-test-'));
+    fs = new NodeFileSystem();
+    
+    // Create test documents with distinct content
+    writeFileSync(join(testVaultPath, 'alpha-document.md'), `# Alpha Document
+
+This document contains information about alpha features.
+It should match searches for "alpha".`);
+
+    writeFileSync(join(testVaultPath, 'beta-features.md'), `# Beta Features
+
+This document describes beta functionality.
+It has nothing to do with alpha.`);
+
+    writeFileSync(join(testVaultPath, 'alpha-and-beta.md'), `# Alpha and Beta Combined
+
+This document mentions both alpha and beta concepts.
+It should match searches for either term.`);
+
+    writeFileSync(join(testVaultPath, 'gamma-notes.md'), `# Gamma Notes
+
+Completely unrelated content about gamma rays.
+Should not match alpha or beta searches.`);
+
+    // Create a document in a subdirectory
+    mkdirSync(join(testVaultPath, 'subfolder'));
+    writeFileSync(join(testVaultPath, 'subfolder', 'nested-alpha.md'), `# Nested Alpha
+
+This alpha document is in a subfolder.`);
+
+    // Initialize indexer
+    indexer = new VaultIndexer({
+      vaultPath: testVaultPath,
+      fileSystem: fs,
+    });
+    await indexer.initialize();
+  });
+
+  afterEach(() => {
+    // Clean up
+    rmSync(testVaultPath, { recursive: true });
+  });
+
+  it('should return all documents when query is empty', async () => {
+    const results = indexer.query({
+      conditions: []
+    });
+    
+    expect(results).toHaveLength(5);
+  });
+
+  it('should filter documents by content containing search term', async () => {
+    const results = indexer.query({
+      conditions: [{
+        field: 'content',
+        operator: 'contains',
+        value: 'alpha'
+      }]
+    });
+    
+    // Should return documents with "alpha" in content
+    expect(results).toHaveLength(3);
+    const names = results.map(doc => doc.basename).sort();
+    expect(names).toEqual(['alpha-and-beta', 'alpha-document', 'nested-alpha']);
+  });
+
+  it('should filter documents by title/name containing search term', async () => {
+    const results = indexer.query({
+      conditions: [{
+        field: 'title',
+        operator: 'contains',
+        value: 'alpha'
+      }]
+    });
+    
+    // Should return documents with "alpha" in title
+    expect(results).toHaveLength(3);
+    const titles = results.map(doc => doc.title).sort();
+    expect(titles).toContain('Alpha Document');
+    expect(titles).toContain('Alpha and Beta Combined');
+    expect(titles).toContain('Nested Alpha');
+  });
+
+  it('should filter documents by basename containing search term', async () => {
+    const results = indexer.query({
+      conditions: [{
+        field: 'fs:name',
+        operator: 'contains',
+        value: 'alpha'
+      }]
+    });
+    
+    // Should return documents with "alpha" in filename
+    expect(results).toHaveLength(3);
+    const names = results.map(doc => doc.basename).sort();
+    expect(names).toEqual(['alpha-and-beta', 'alpha-document', 'nested-alpha']);
+  });
+
+  it('should return empty array when no documents match', async () => {
+    const results = indexer.query({
+      conditions: [{
+        field: 'content',
+        operator: 'contains',
+        value: 'zeta'
+      }]
+    });
+    
+    expect(results).toHaveLength(0);
+  });
+
+  it('should be case insensitive for content searches', async () => {
+    const upperResults = indexer.query({
+      conditions: [{
+        field: 'content',
+        operator: 'contains',
+        value: 'ALPHA'
+      }]
+    });
+    
+    const lowerResults = indexer.query({
+      conditions: [{
+        field: 'content',
+        operator: 'contains',
+        value: 'alpha'
+      }]
+    });
+    
+    expect(upperResults).toHaveLength(3);
+    expect(lowerResults).toHaveLength(3);
+    expect(upperResults.map(d => d.basename).sort()).toEqual(
+      lowerResults.map(d => d.basename).sort()
+    );
+  });
+
+  it('should handle partial matches', async () => {
+    const results = indexer.query({
+      conditions: [{
+        field: 'content',
+        operator: 'contains',
+        value: 'alph'
+      }]
+    });
+    
+    // Should match "alpha" documents
+    expect(results).toHaveLength(3);
+  });
+
+  it('should combine multiple conditions with AND logic', async () => {
+    const results = indexer.query({
+      conditions: [
+        {
+          field: 'content',
+          operator: 'contains',
+          value: 'alpha'
+        },
+        {
+          field: 'content',
+          operator: 'contains',
+          value: 'beta'
+        }
+      ]
+    });
+    
+    // Only documents with both alpha AND beta
+    expect(results).toHaveLength(1);
+    expect(results[0].basename).toBe('alpha-and-beta');
+  });
+
+  it('should search in path for path queries', async () => {
+    const results = indexer.query({
+      conditions: [{
+        field: 'fs:path',
+        operator: 'contains',
+        value: 'subfolder'
+      }]
+    });
+    
+    expect(results).toHaveLength(1);
+    expect(results[0].basename).toBe('nested-alpha');
+  });
+
+  it('should work with the simplified string query API if provided', async () => {
+    // If the indexer supports a simple string query API
+    // This would search across name, title, content, and path
+    // For now, let's test what the API expects
+    const results = indexer.query({
+      conditions: [{
+        field: 'content',
+        operator: 'contains',
+        value: 'beta'
+      }]
+    });
+    
+    expect(results).toHaveLength(2);
+    const names = results.map(doc => doc.basename).sort();
+    expect(names).toEqual(['alpha-and-beta', 'beta-features']);
+  });
+});


### PR DESCRIPTION
## Summary
- Fixed query-executor to properly filter documents when searching content field (was always returning true)
- Implemented content search across metadata fields (title, basename, path, aliases, tags) since actual file content isn't stored in metadata
- Added z.coerce to DocumentsQuerySchema for proper query param type conversion (fixes 400 errors)
- Removed unnecessary async/await from synchronous indexer methods
- Added comprehensive test suite for search functionality

## Test plan
- [x] Added search-functionality.test.ts for indexer-level search testing
- [x] Added search-documents.test.js for API-level search testing
- [x] All tests pass for API server package
- [x] Search now properly filters results instead of returning all documents

Fixes #115

🤖 Generated with [Claude Code](https://claude.ai/code)