### PR TITLE
Fix ESLint errors in web app

### DIFF
--- a/apps/web/src/components/FilterBar.jsx
+++ b/apps/web/src/components/FilterBar.jsx
@@ -6,7 +6,7 @@ import { MultiSelectDropdown } from './MultiSelectDropdown';
 import { MetadataFilter } from './MetadataFilter';
 
 export function FilterBar() {
-  const { documents, filteredDocuments, totalCount, vaultTotal, filters, setFilters } = useDocumentStore();
+  const { documents, filteredDocuments, vaultTotal, filters, setFilters } = useDocumentStore();
   const [localFilters, setLocalFilters] = useState(filters || {});
   
   // Apply filters when they change
@@ -60,10 +60,6 @@ export function FilterBar() {
     return parts.length > 0 ? ' | ' + parts.join(' | ') : '';
   };
   
-  // Get tooltip for folder/tag counts
-  const getFolderTooltip = () => {
-    return localFilters.folders?.join('\n') || '';
-  };
   
 
   return (

--- a/apps/web/src/components/MetadataFilter.jsx
+++ b/apps/web/src/components/MetadataFilter.jsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useMemo } from 'react';
+import { useState, useMemo } from 'react';
 import { Input } from '@/components/ui/input';
 import { Badge } from '@/components/ui/badge';
 import { X } from 'lucide-react';

--- a/apps/web/tests/css-loading.test.js
+++ b/apps/web/tests/css-loading.test.js
@@ -7,7 +7,7 @@ describe('CSS Loading', () => {
 
   beforeAll(() => {
     // Read the globals.css file
-    const cssPath = path.join(process.cwd(), 'src', 'globals.css');
+    const cssPath = path.join(path.dirname(new URL(import.meta.url).pathname), '..', 'src', 'globals.css');
     cssContent = fs.readFileSync(cssPath, 'utf-8');
   });
 

--- a/apps/web/tests/dark-theme.test.jsx
+++ b/apps/web/tests/dark-theme.test.jsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import App from '../src/App';
 

--- a/apps/web/tests/table-rendering.test.jsx
+++ b/apps/web/tests/table-rendering.test.jsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
 import '@testing-library/jest-dom';
 import { TableView } from '@mmt/table-view';
 


### PR DESCRIPTION
## Summary
- Fixed all 7 ESLint errors in the web app
- No functional changes, only removed unused imports and variables

## Changes
- `FilterBar.jsx`: Removed unused `totalCount` and `getFolderTooltip` function
- `MetadataFilter.jsx`: Removed unused `useEffect` import  
- `css-loading.test.js`: Fixed `process` undefined error by using `import.meta.url`
- `dark-theme.test.jsx`: Removed unused `screen` import
- `table-rendering.test.jsx`: Removed unused `vi` and `screen` imports

## Test plan
- [x] Run `pnpm --filter '@mmt/web' lint` - passes with no errors
- [x] Run `pnpm --filter '@mmt/web' test` - existing tests still pass

Fixes #88

🤖 Generated with [Claude Code](https://claude.ai/code)