### PR TITLE
feat: update configuration schema to support multiple vaults

### DIFF
--- a/apps/api-server/src/app.ts
+++ b/apps/api-server/src/app.ts
@@ -22,10 +22,14 @@ export async function createApp(config: Config): Promise<Express> {
   
   // Initialize services
   const fs = new NodeFileSystem();
+  
+  // For Phase 1: Use the first vault as default
+  const defaultVault = config.vaults[0];
+  
   const indexer = new VaultIndexer({
-    vaultPath: config.vaultPath,
+    vaultPath: defaultVault.path,
     fileSystem: fs,
-    cacheDir: config.indexPath,
+    cacheDir: defaultVault.indexPath,
     useCache: true
   });
   await indexer.initialize();
@@ -40,13 +44,13 @@ export async function createApp(config: Config): Promise<Express> {
     
     // Hook similarity search into indexer's file changes
     // For now, we'll set up our own file watcher that mirrors the indexer's behavior
-    if (config.fileWatching?.enabled) {
+    if (defaultVault.fileWatching?.enabled) {
       const { FileWatcher } = await import('@mmt/vault');
       const similarityWatcher = new FileWatcher({
-        paths: [config.vaultPath],
+        paths: [defaultVault.path],
         recursive: true,
-        debounceMs: config.fileWatching.debounceMs,
-        ignorePatterns: config.fileWatching.ignorePatterns,
+        debounceMs: defaultVault.fileWatching.debounceMs,
+        ignorePatterns: defaultVault.fileWatching.ignorePatterns,
       });
       
       similarityWatcher.onFileChange(async (event) => {
@@ -88,8 +92,8 @@ export async function createApp(config: Config): Promise<Express> {
   app.get('/health', (req, res) => {
     res.json({
       status: 'ok',
-      vaultPath: config.vaultPath,
-      indexPath: config.indexPath
+      vaultPath: defaultVault.path,
+      indexPath: defaultVault.indexPath
     });
   });
   

--- a/apps/api-server/src/context.ts
+++ b/apps/api-server/src/context.ts
@@ -24,12 +24,15 @@ export async function createContext(): Promise<Context> {
   // Initialize services
   const fs = new NodeFileSystem();
   
+  // For Phase 1: Use the first vault as default
+  const defaultVault = config.vaults[0];
+  
   const indexer = new VaultIndexer({
-    vaultPath: config.vaultPath,
+    vaultPath: defaultVault.path,
     fileSystem: fs,
-    cacheDir: config.indexPath,
+    cacheDir: defaultVault.indexPath,
     useCache: true,
-    fileWatching: config.fileWatching,
+    fileWatching: defaultVault.fileWatching,
   });
   await indexer.initialize();
   

--- a/apps/api-server/src/index.ts
+++ b/apps/api-server/src/index.ts
@@ -37,8 +37,10 @@ async function main() {
   // Start server
   app.listen(PORT, () => {
     console.log(`MMT API Server running on http://localhost:${PORT}`);
-    console.log(`Vault path: ${context.config.vaultPath}`);
-    console.log(`Index path: ${context.config.indexPath}`);
+    console.log(`Vaults configured: ${context.config.vaults.length}`);
+    context.config.vaults.forEach((vault, index) => {
+      console.log(`  ${index === 0 ? '[Active]' : '       '} ${vault.name}: ${vault.path}`);
+    });
   });
 }
 

--- a/apps/api-server/src/routes/config.ts
+++ b/apps/api-server/src/routes/config.ts
@@ -6,14 +6,15 @@ export function configRouter(context: Context): Router {
   
   // GET /api/config - Get current configuration
   router.get('/', (req, res) => {
+    // For Phase 1: Return all vaults with the first one marked as active
     res.json({
-      vaultPath: context.config.vaultPath,
-      indexPath: context.config.indexPath,
-      fileWatching: context.config.fileWatching ? {
-        enabled: context.config.fileWatching.enabled,
-        debounceMs: context.config.fileWatching.debounceMs,
-        ignorePatterns: context.config.fileWatching.ignorePatterns,
-      } : undefined,
+      vaults: context.config.vaults.map((vault, index) => ({
+        ...vault,
+        active: index === 0 // First vault is active by default
+      })),
+      apiPort: context.config.apiPort,
+      webPort: context.config.webPort,
+      similarity: context.config.similarity,
     });
   });
   
@@ -21,10 +22,14 @@ export function configRouter(context: Context): Router {
   router.get('/stats', async (req, res, next) => {
     try {
       const documents = await context.indexer.getAllDocuments();
+      const activeVault = context.config.vaults[0]; // First vault is active
       res.json({
         totalDocuments: documents.length,
-        vaultPath: context.config.vaultPath,
-        indexPath: context.config.indexPath,
+        activeVault: {
+          name: activeVault.name,
+          path: activeVault.path,
+          indexPath: activeVault.indexPath,
+        }
       });
     } catch (error) {
       next(error);

--- a/apps/api-server/src/routes/documents.ts
+++ b/apps/api-server/src/routes/documents.ts
@@ -501,7 +501,8 @@ export function documentsRouter(context: Context): Router {
         
         // Apply filters if provided
         if (filterCollection && filterCollection.conditions.length > 0) {
-          results = applyDeclarativeFilters(results, filterCollection, context.config.vaultPath);
+          const defaultVault = context.config.vaults[0];
+          results = applyDeclarativeFilters(results, filterCollection, defaultVault.path);
         }
         
         // Sort BEFORE pagination if requested

--- a/apps/api-server/src/routes/similarity.ts
+++ b/apps/api-server/src/routes/similarity.ts
@@ -129,7 +129,8 @@ export function similarityRouter(context: Context): Router {
       }
       
       // Start reindexing in the background
-      context.similaritySearch!.indexDirectory(context.config.vaultPath)
+      const defaultVault = context.config.vaults[0];
+      context.similaritySearch!.indexDirectory(defaultVault.path)
         .catch(error => {
           console.error('Reindexing failed:', error);
         });

--- a/apps/api-server/src/server.ts
+++ b/apps/api-server/src/server.ts
@@ -24,8 +24,10 @@ async function start(): Promise<void> {
     
     app.listen(config.apiPort, () => {
       console.log(`MMT API Server running on http://localhost:${config.apiPort}`);
-      console.log(`Vault: ${config.vaultPath}`);
-      console.log(`Index: ${config.indexPath}`);
+      console.log(`Vaults configured: ${config.vaults.length}`);
+      config.vaults.forEach((vault, index) => {
+        console.log(`  ${index === 0 ? '[Active]' : '       '} ${vault.name}: ${vault.path}`);
+      });
     });
   } catch (error) {
     console.error('Failed to start server:', error);

--- a/apps/api-server/src/services/pipeline-executor.ts
+++ b/apps/api-server/src/services/pipeline-executor.ts
@@ -203,9 +203,10 @@ export class PipelineExecutor {
         if (typeof filePath !== 'string') continue;
         
         // Check if filePath is already absolute
+        const defaultVault = this.context.config.vaults[0];
         const fullPath = filePath.startsWith('/') || (process.platform === 'win32' && /^[A-Za-z]:[\\/]/u.test(filePath)) 
           ? filePath 
-          : join(this.context.config.vaultPath, filePath);
+          : join(defaultVault.path, filePath);
         const exists = await this.context.fs.exists(fullPath);
         
         if (exists) {
@@ -324,8 +325,9 @@ export class PipelineExecutor {
   }
 
   private createOperationContext(): OperationContext {
+    const defaultVault = this.context.config.vaults[0];
     return {
-      vault: { path: this.context.config.vaultPath },
+      vault: { path: defaultVault.path },
       fs: this.context.fs,
       indexer: this.context.indexer,
       options: {

--- a/apps/api-server/src/services/similarity-search.ts
+++ b/apps/api-server/src/services/similarity-search.ts
@@ -70,8 +70,10 @@ export class SimilaritySearchService extends EventEmitter {
   constructor(config: Config) {
     super();
     this.config = config;
+    // For Phase 1: Use first vault's index path
+    const defaultVault = config.vaults[0];
     this.indexPath = path.join(
-      config.indexPath,
+      defaultVault.indexPath,
       config.similarity?.indexFilename || 'similarity-index.msp'
     );
   }

--- a/apps/cli/src/application-director.ts
+++ b/apps/cli/src/application-director.ts
@@ -90,11 +90,11 @@ export class ApplicationDirector {
       const config = configService.load(cliArgs.configPath);
       
       // Override file watching setting with CLI flag if provided
-      if (cliArgs.watch) {
-        config.fileWatching = {
+      if (cliArgs.watch && config.vaults[0]) {
+        config.vaults[0].fileWatching = {
           enabled: true,
-          debounceMs: config.fileWatching?.debounceMs ?? 100,
-          ignorePatterns: config.fileWatching?.ignorePatterns ?? [
+          debounceMs: config.vaults[0].fileWatching?.debounceMs ?? 100,
+          ignorePatterns: config.vaults[0].fileWatching?.ignorePatterns ?? [
             '.git/**',
             '.obsidian/**',
             '.trash/**',

--- a/apps/cli/src/commands/script-command.ts
+++ b/apps/cli/src/commands/script-command.ts
@@ -35,11 +35,12 @@ export class ScriptCommand implements CommandHandler {
       scriptArgs: args.slice(1),
     });
     
+    const defaultVault = context.config.vaults[0];
     debugLog('Script command received:', {
       scriptPath: scriptArgs.scriptPath,
       scriptArgs: scriptArgs.scriptArgs,
-      vaultPath: context.config.vaultPath,
-      indexPath: context.config.indexPath,
+      vaultPath: defaultVault.path,
+      indexPath: defaultVault.indexPath,
     });
     
     // Resolve script path

--- a/dev-config.yaml
+++ b/dev-config.yaml
@@ -1,8 +1,11 @@
 # Development configuration
-vaultPath: /Users/danielseltzer/code/mmt/test-vault
-indexPath: /Users/danielseltzer/code/mmt/.index
-fileWatching:
-  enabled: true
-  debounceMs: 500
+vaults:
+  - name: 'Test Vault'
+    path: /Users/danielseltzer/code/mmt/test-vault
+    indexPath: /Users/danielseltzer/code/mmt/.index
+    fileWatching:
+      enabled: true
+      debounceMs: 500
+
 apiPort: 3001
 webPort: 5173

--- a/packages/entities/src/index.test.ts
+++ b/packages/entities/src/index.test.ts
@@ -19,12 +19,17 @@ import {
 describe('Entity Schemas', () => {
   describe('ConfigSchema', () => {
     it('should validate valid config', () => {
-      // GIVEN: A config object with required paths
+      // GIVEN: A config object with required vaults array
       // WHEN: Validating against ConfigSchema
-      // THEN: Valid because both vaultPath and indexPath are absolute paths
+      // THEN: Valid because vaults contain name, path, and indexPath
       const config: Config = {
-        vaultPath: '/Users/test/vault',
-        indexPath: '/Users/test/.mmt/index',
+        vaults: [
+          {
+            name: 'TestVault',
+            path: '/Users/test/vault',
+            indexPath: '/Users/test/.mmt/index',
+          }
+        ],
         apiPort: 3001,
         webPort: 5173,
       };
@@ -33,13 +38,14 @@ describe('Entity Schemas', () => {
       expect(result.success).toBe(true);
     });
 
-    it('should require both vaultPath and indexPath', () => {
-      // GIVEN: A config missing required indexPath
+    it('should require vaults array', () => {
+      // GIVEN: A config missing required vaults array
       // WHEN: Validating against ConfigSchema
-      // THEN: Invalid because both paths are required (no defaults policy)
+      // THEN: Invalid because vaults is required (no defaults policy)
       const config = {
-        vaultPath: '/Users/test/vault',
-        // missing indexPath
+        apiPort: 3001,
+        webPort: 5173,
+        // missing vaults
       };
       
       const result = ConfigSchema.safeParse(config);
@@ -49,9 +55,11 @@ describe('Entity Schemas', () => {
     it('should reject invalid config', () => {
       // GIVEN: A config with wrong data types
       // WHEN: Validating against ConfigSchema
-      // THEN: Invalid because vaultPath must be a string, not a number
+      // THEN: Invalid because vaults must be an array, not a string
       const invalidConfig = {
-        vaultPath: 123, // Should be string
+        vaults: 'not-an-array', // Should be array
+        apiPort: 3001,
+        webPort: 5173,
       };
       
       const result = ConfigSchema.safeParse(invalidConfig);

--- a/personal-vault-config.yaml
+++ b/personal-vault-config.yaml
@@ -1,11 +1,12 @@
 # Configuration for personal vault snapshot
-vaultPath: /Users/danielseltzer/Notes/Personal-sync-250710
-indexPath: /Users/danielseltzer/code/mmt/.index-personal
-
-# Enable file watching for automatic updates
-fileWatching:
-  enabled: true
-  debounceMs: 200
+vaults:
+  - name: 'Personal'
+    path: /Users/danielseltzer/Notes/Personal-sync-250710
+    indexPath: /Users/danielseltzer/code/mmt/.index-personal
+    # Enable file watching for automatic updates
+    fileWatching:
+      enabled: true
+      debounceMs: 200
 
 # Required port settings
 apiPort: 3001


### PR DESCRIPTION
## Summary
Implements Phase 1 of multi-vault support by updating the configuration schema to support multiple vault definitions.

## Changes
- ✅ Added `VaultConfigSchema` for individual vault configurations
- ✅ Updated `ConfigSchema` to use `vaults` array instead of single `vaultPath`/`indexPath`
- ✅ Migrated existing config files to new format
- ✅ Updated all packages to use `config.vaults[0]` as default vault
- ✅ Updated control manager to parse new config format
- ✅ Added vault name uniqueness validation

## Implementation Strategy
This PR uses "first vault as default" pattern to avoid massive refactoring of function signatures throughout the codebase. Full vault context architecture will be implemented in #186.

## Testing
- [x] Config package tests pass
- [x] Entities package tests pass  
- [x] API server starts and responds correctly
- [x] Control manager (`./bin/mmt`) works with new config format

## Example Config
```yaml
vaults:
  - name: 'Personal'
    path: /Users/me/personal-vault
    indexPath: /Users/me/.mmt/personal-index
  - name: 'Work'
    path: /Users/me/work-vault
    indexPath: /Users/me/.mmt/work-index
apiPort: 3001
webPort: 5173
```

## Related Issues
- Closes #156
- Follow-up: #186 (Establish vault context as first-class domain concept)
- Bug found: #187 (Fix missing web utility files)

🤖 Generated with [Claude Code](https://claude.ai/code)